### PR TITLE
Ensure unique colors for external debt categories

### DIFF
--- a/app.py
+++ b/app.py
@@ -191,10 +191,13 @@ if pagina == 'Deuda externa':
         df_pais = df_filtrado[["SC3", "Time", pais]].dropna()
         # Tomar el valor máximo por año y SC3 para evitar duplicados (mantiene el valor más significativo)
         df_pais_agg = df_pais.groupby(['Time', 'SC3'])[pais].max().reset_index()
-        # Paleta de colores para categorías de deuda externa
-        palette_sc3 = ['#FF6B35', '#F7C59F', '#EFEFD0', '#789FAD', '#004E89', '#7C8A94']
+        # Paleta de colores única para categorías de deuda externa
         sc3_categories = df_pais_agg['SC3'].unique()
-        sc3_color_map = {cat: palette_sc3[i % len(palette_sc3)] for i, cat in enumerate(sc3_categories)}
+        palette_sc3 = px.colors.sample_colorscale(
+            'Viridis',
+            [n / max(len(sc3_categories) - 1, 1) for n in range(len(sc3_categories))]
+        )
+        sc3_color_map = {cat: palette_sc3[i] for i, cat in enumerate(sc3_categories)}
         st.markdown('**Serie temporal de deuda por SC3 (Stacked Bar)**')
         fig1 = px.bar(
             df_pais_agg,


### PR DESCRIPTION
## Summary
- Generate a unique color for each SC3 category in external debt graphs.
- Apply the same distinct colors to both USD and percentage stacked bar charts.

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894cca1ca54833088526b2623a7ee64