### PR TITLE
Restrict SC2 options in Plazos y Tasas filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -388,8 +388,14 @@ elif pagina == 'Plazos y Tasas':
     # Filtro Multilateral y SC2
     multilaterales = df['Multilateral'].dropna().unique()
     multilateral = st.sidebar.selectbox('Selecciona Multilateral', multilaterales)
-    sc2_options = df['SC2'].dropna().unique() if 'SC2' in df.columns else []
-    sc2 = st.sidebar.selectbox('Selecciona SC2', sc2_options) if len(sc2_options) > 0 else None
+    sc2_allowed = [
+        'Average grace period on new external commitments',
+        'Average grant element on new external debt commitments',
+        'Average interest on new external debt commitments',
+        'Average maturity on new external debt commitments',
+    ]
+    sc2_options = [opt for opt in sc2_allowed if 'SC2' in df.columns and opt in df['SC2'].dropna().unique()]
+    sc2 = st.sidebar.selectbox('Selecciona SC2', sc2_options) if sc2_options else None
     df_filtrado = df[df['Multilateral'] == multilateral]
     if sc2 is not None:
         df_filtrado = df_filtrado[df_filtrado['SC2'] == sc2]


### PR DESCRIPTION
## Summary
- limit SC2 dropdown on the Plazos y Tasas page to specific average-term metrics

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6894d6173cec8330bde0e001732425f1