### PR TITLE
Handle None values in sector list

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -374,7 +374,7 @@ def render():
 
     # -------- Tab 1: Comparador A vs B --------
     with tabs[1]:
-        sector_list = sorted(df_f["sector_codename"].unique())
+        sector_list = sorted(df_f["sector_codename"].dropna().unique())
         col1, col2 = st.columns(2)
         with col1:
             sector_a = st.selectbox("Sector A", sector_list, key="sector_a")


### PR DESCRIPTION
## Summary
- Avoid sorting None sector names by dropping missing sector_codename entries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cabcecc748330a01d50f12955b8ea