### PR TITLE
Add title to Matrices de concentración page

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -234,6 +234,7 @@ def render():
             st.dataframe(summary, use_container_width=True)
 
     elif subpage == "Matrices de concentración":
+        st.title("Matrices de concentración")
         focus_countries = ["AR", "BO", "BR", "PY", "UY"]
         df_focus = df_f[df_f["recipientcountry_code"].isin(focus_countries)]
         pivot = (


### PR DESCRIPTION
## Summary
- Add title to the Matrices de concentración page in sectors view for clarity

## Testing
- `python -m py_compile sectores_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd3602c1c8330aee899293fd8cee6