### PR TITLE
Format country metrics without decimals

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -231,6 +231,12 @@ def render():
                     "monto": "Monto (millones USD)",
                 }
             )
+            summary["Ticket prom. (millones USD)"] = (
+                summary["Ticket prom. (millones USD)"].round().astype(int)
+            )
+            summary["Monto (millones USD)"] = (
+                summary["Monto (millones USD)"].round().astype(int)
+            )
             st.dataframe(summary, use_container_width=True)
 
     elif subpage == "Matrices de concentración":


### PR DESCRIPTION
## Summary
- Round ticket average and total amount columns in Ficha de sector country tables to display whole numbers

## Testing
- `python -m py_compile sectores_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd7b7f0ec83308ccf61359b5c164c