### PR TITLE
Place legend below comparador A vs B bar chart

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -169,6 +169,16 @@ def render():
             color_discrete_map=color_map,
             barmode="stack",
         )
+        fig_bar.update_layout(
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=-0.2,
+                xanchor="center",
+                x=0.5,
+                title_text="",
+            )
+        )
         st.plotly_chart(fig_bar, use_container_width=True)
         col_a, col_b = st.columns(2)
         for col, (sector, source, country) in zip(


### PR DESCRIPTION
## Summary
- Move legend below the A vs B comparison bar chart for better visualization

## Testing
- `python -m py_compile sectores_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689cdb881cbc8330843e908d11a9ad23