### PR TITLE
Invertir ejes de heatmap sector-años

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -359,6 +359,7 @@ def render():
             )
         )
         pivot2 = pivot2.div(pivot2.sum(axis=1), axis=0).fillna(0) * 100
+        pivot2 = pivot2.T
         fig_heat2 = go.Figure(
             data=go.Heatmap(
                 z=pivot2.values,


### PR DESCRIPTION
## Summary
- Transpose sector-year pivot to display years on the x-axis and macro sectors on the y-axis in the concentration heatmap.

## Testing
- `python -m py_compile sectores_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689df35856508330a1d582a38825c5a7