### PR TITLE
Display most intense sectors at top of concentration matrices

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -375,6 +375,7 @@ def render():
                 hovertemplate="%{y} - %{x}: %{z:.1f}%<extra></extra>",
             )
         )
+        fig_heat.update_yaxes(autorange="reversed")
         st.plotly_chart(fig_heat, use_container_width=True)
 
         pivot2 = (
@@ -401,6 +402,7 @@ def render():
                 hovertemplate="%{y} - %{x}: %{z:.1f}%<extra></extra>",
             )
         )
+        fig_heat2.update_yaxes(autorange="reversed")
         st.plotly_chart(fig_heat2, use_container_width=True)
 
     elif subpage == "Intensidad y estructura":


### PR DESCRIPTION
## Summary
- Reverse y-axis ordering in concentration matrix heatmaps to show highest-intensity sectors at the top

## Testing
- `python -m py_compile sectores_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689e4dc3b9548330bce591db8ac5da77