### PR TITLE
Hide legends on Panorama column charts

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -193,6 +193,7 @@ def render():
                 color_discrete_map=macro_color_map,
                 barmode="stack",
             )
+            fig_stack.update_layout(showlegend=False)
             st.plotly_chart(fig_stack, use_container_width=True)
 
         with col_percent:
@@ -215,6 +216,7 @@ def render():
                 barmode="stack",
             )
             fig_percent.update_yaxes(range=[0, 100])
+            fig_percent.update_layout(showlegend=False)
             st.plotly_chart(fig_percent, use_container_width=True)
 
     elif subpage == "Comparador A vs B":


### PR DESCRIPTION
## Summary
- Hide legends on the stacked and percentage column charts in the Panorama de Sectores page for a cleaner view.

## Testing
- `python -m py_compile sectores_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3606a3f088330ab34024e387b5809