### PR TITLE
fix: remove invalid streamlit columns import

### DIFF
--- a/app.py
+++ b/app.py
@@ -379,8 +379,7 @@ elif pagina == 'Plazos y Tasas':
 
     # Gráficos organizados en filas
     import plotly.express as px
-    from streamlit import columns
-    
+
     # Primera fila: Argentina y Bolivia
     col1, col2 = st.columns(2)
     
@@ -502,8 +501,7 @@ elif pagina == 'Comprometido':
     
     if paises_disponibles:
         import plotly.express as px
-        from streamlit import columns
-        
+
         # Primera fila: Argentina y Bolivia
         col1, col2 = st.columns(2)
         


### PR DESCRIPTION
## Summary
- remove `from streamlit import columns` statements
- rely on `st.columns` directly for layout

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68b882647fb083309ba0b6e4b3f72057