### PR TITLE
feat: add filters for Sankey diagram

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -614,76 +614,106 @@ def render():
             .reset_index()
         )
         sankey_df["value_usd"] = sankey_df["value_usd"] / 1e6
-        sources_nodes = sankey_df["source"].unique().tolist()
-        macro_nodes = sankey_df["macro_sector"].unique().tolist()
-        country_nodes = sankey_df["recipientcountry_codename"].unique().tolist()
-        nodes = sources_nodes + macro_nodes + country_nodes
-        node_indices = {name: i for i, name in enumerate(nodes)}
 
-        # Filtros específicos para el diagrama de Sankey
-        focus_options = ["Todos", "MDBs", "Países", "Macro sectores"]
-        focus = st.selectbox("Resaltar en Sankey", focus_options, index=0)
-        focus_value = None
-        if focus == "MDBs":
-            focus_value = st.selectbox("MDB", sources_nodes)
-        elif focus == "Países":
-            focus_value = st.selectbox("País", country_nodes)
-        elif focus == "Macro sectores":
-            focus_value = st.selectbox("Macro sector", macro_nodes)
-
-        link_colors = []
-        links = {"source": [], "target": [], "value": [], "color": link_colors}
-        source_palette = px.colors.qualitative.Plotly
-        custom_colors = {
-            "FONPLATA": "#c1121f",
-            "IADB": "#006494",
-            "WorldBank": "#1b4965",
-            "CAF": "#38b000",
-        }
-        source_color_map = {
-            s: custom_colors.get(s, source_palette[i % len(source_palette)])
-            for i, s in enumerate(sources_nodes)
-        }
-
-        grey_color = "rgba(200,200,200,0.2)"
-
-        def highlight_row(row):
-            if focus == "MDBs" and focus_value:
-                return row.source == focus_value
-            if focus == "Países" and focus_value:
-                return row.recipientcountry_codename == focus_value
-            if focus == "Macro sectores" and focus_value:
-                return row.macro_sector == focus_value
-            return True
-
-        for row in sankey_df.itertuples():
-            color = source_color_map[row.source]
-            highlight = highlight_row(row)
-            links["source"].append(node_indices[row.source])
-            links["target"].append(node_indices[row.macro_sector])
-            links["value"].append(row.value_usd)
-            link_colors.append(color if highlight else grey_color)
-        for row in sankey_df.itertuples():
-            color = source_color_map[row.source]
-            highlight = highlight_row(row)
-            links["source"].append(node_indices[row.macro_sector])
-            links["target"].append(node_indices[row.recipientcountry_codename])
-            links["value"].append(row.value_usd)
-            link_colors.append(color if highlight else grey_color)
-
-        fig_sankey = go.Figure(
-            go.Sankey(
-                node=dict(label=nodes),
-                link=dict(
-                    source=links["source"],
-                    target=links["target"],
-                    value=links["value"],
-                    color=links["color"],
-                ),
-            )
+        # Filtros para el diagrama de Sankey
+        all_sources = sorted(sankey_df["source"].unique().tolist())
+        all_countries = sorted(
+            sankey_df["recipientcountry_codename"].unique().tolist()
         )
-        fig_sankey.update_layout(height=600, width=1000)
-        st.plotly_chart(fig_sankey, use_container_width=True)
+        all_macros = sorted(sankey_df["macro_sector"].unique().tolist())
+        filter_cols = st.columns(3)
+        with filter_cols[0]:
+            sankey_sources = st.multiselect(
+                "MDBs (Sankey)", all_sources, default=all_sources
+            )
+        with filter_cols[1]:
+            sankey_countries = st.multiselect(
+                "Países (Sankey)", all_countries, default=all_countries
+            )
+        with filter_cols[2]:
+            sankey_macros = st.multiselect(
+                "Macro sectores (Sankey)", all_macros, default=all_macros
+            )
+        sankey_df = sankey_df[
+            sankey_df["source"].isin(sankey_sources)
+            & sankey_df["recipientcountry_codename"].isin(sankey_countries)
+            & sankey_df["macro_sector"].isin(sankey_macros)
+        ]
+        if sankey_df.empty:
+            st.warning("No hay datos para las selecciones del Sankey")
+        else:
+            sources_nodes = sorted(sankey_df["source"].unique().tolist())
+            macro_nodes = sorted(sankey_df["macro_sector"].unique().tolist())
+            country_nodes = sorted(
+                sankey_df["recipientcountry_codename"].unique().tolist()
+            )
+            nodes = sources_nodes + macro_nodes + country_nodes
+            node_indices = {name: i for i, name in enumerate(nodes)}
+
+            # Filtros específicos para resaltar en el diagrama
+            focus_options = ["Todos", "MDBs", "Países", "Macro sectores"]
+            focus = st.selectbox("Resaltar en Sankey", focus_options, index=0)
+            focus_value = None
+            if focus == "MDBs" and sources_nodes:
+                focus_value = st.selectbox("MDB", sources_nodes)
+            elif focus == "Países" and country_nodes:
+                focus_value = st.selectbox("País", country_nodes)
+            elif focus == "Macro sectores" and macro_nodes:
+                focus_value = st.selectbox("Macro sector", macro_nodes)
+
+            link_colors = []
+            links = {"source": [], "target": [], "value": [], "color": link_colors}
+            source_palette = px.colors.qualitative.Plotly
+            custom_colors = {
+                "FONPLATA": "#c1121f",
+                "IADB": "#006494",
+                "WorldBank": "#1b4965",
+                "CAF": "#38b000",
+            }
+            source_color_map = {
+                s: custom_colors.get(s, source_palette[i % len(source_palette)])
+                for i, s in enumerate(sources_nodes)
+            }
+
+            grey_color = "rgba(200,200,200,0.2)"
+
+            def highlight_row(row):
+                if focus == "MDBs" and focus_value:
+                    return row.source == focus_value
+                if focus == "Países" and focus_value:
+                    return row.recipientcountry_codename == focus_value
+                if focus == "Macro sectores" and focus_value:
+                    return row.macro_sector == focus_value
+                return True
+
+            for row in sankey_df.itertuples():
+                color = source_color_map[row.source]
+                highlight = highlight_row(row)
+                links["source"].append(node_indices[row.source])
+                links["target"].append(node_indices[row.macro_sector])
+                links["value"].append(row.value_usd)
+                link_colors.append(color if highlight else grey_color)
+            for row in sankey_df.itertuples():
+                color = source_color_map[row.source]
+                highlight = highlight_row(row)
+                links["source"].append(node_indices[row.macro_sector])
+                links["target"].append(node_indices[row.recipientcountry_codename])
+                links["value"].append(row.value_usd)
+                link_colors.append(color if highlight else grey_color)
+
+            fig_sankey = go.Figure(
+                go.Sankey(
+                    node=dict(label=nodes),
+                    link=dict(
+                        source=links["source"],
+                        target=links["target"],
+                        value=links["value"],
+                        color=links["color"],
+                    ),
+                )
+            )
+            fig_sankey.update_layout(height=600, width=1000)
+            st.plotly_chart(fig_sankey, use_container_width=True)
 
     elif subpage == "Tabla maestra":
         cols = [


### PR DESCRIPTION
## Summary
- add dedicated multiselect filters for MDBs, countries and macro sectors in Sankey view
- handle empty Sankey selections and build diagram from filtered data

## Testing
- `python -m py_compile sectores_page.py`
- `python -m py_compile app.py macrosectores.py`


------
https://chatgpt.com/codex/tasks/task_e_68b992db01088330aa61752322ba83aa