### PR TITLE
Fix participation chart bar normalization

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -471,13 +471,12 @@ def render():
             fig_pct = px.bar(
                 dist_df,
                 x="year",
-                y="cumulative_value",
+                y="share",
                 color="source",
-                barnorm="percent",
                 color_discrete_map=color_map,
                 labels={
                     "year": "Año acumulado",
-                    "cumulative_value": "Monto acumulado (millones USD)",
+                    "share": "Participación acumulada",
                     "source": "MDB",
                 },
                 custom_data=["share", "cumulative_value"],
@@ -491,7 +490,7 @@ def render():
                     "<extra></extra>"
                 )
             )
-            fig_pct.update_yaxes(range=[0, 100], title="Participación (%)")
+            fig_pct.update_yaxes(range=[0, 1], tickformat=".0%", title="Participación (%)")
             fig_pct.update_layout(
                 showlegend=(label == "A"),
                 legend=dict(


### PR DESCRIPTION
## Summary
- plot cumulative participation chart using precomputed share values instead of Plotly's `barnorm`
- format the y-axis as percentages to keep the participation presentation consistent

## Testing
- python -m compileall sectores_page.py

------
https://chatgpt.com/codex/tasks/task_e_68d1ab7361c08330bdc5dcffe8f37750