### PR TITLE
Fix subplot annotation axis references

### DIFF
--- a/sectores_page.py
+++ b/sectores_page.py
@@ -473,12 +473,14 @@ def render():
             dist_results, start=1
         ):
             if dist_df is None or dist_df.empty:
+                x_axis = "x" if idx == 1 else f"x{idx}"
+                y_axis = "y" if idx == 1 else f"y{idx}"
                 fig_pct.add_annotation(
                     text="No hay datos para la selección realizada en este comparador.",
                     x=0.5,
                     y=0.5,
-                    xref=f"x{idx} domain",
-                    yref=f"y{idx} domain",
+                    xref=f"{x_axis} domain",
+                    yref=f"{y_axis} domain",
                     showarrow=False,
                     font=dict(color="#666", size=12),
                 )


### PR DESCRIPTION
## Summary
- correct subplot annotation axis references used when no comparator data is available
- avoid Plotly ValueError raised by invalid xref/yref values for the first subplot

## Testing
- python -m compileall sectores_page.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c05880f8833096e36f3dc44aca37