### PR TITLE
Handle limited year data in dashboards

### DIFF
--- a/financiamiento_page.py
+++ b/financiamiento_page.py
@@ -48,10 +48,16 @@ def render() -> None:
     df["recipientcountry_codename"] = df["recipientcountry_codename"].fillna("Sin dato")
     df["transaction_year"] = df["transactiondate_isodate"].dt.year
 
-    df = df[df["transaction_year"] >= 2013]
-    if df.empty:
-        st.info("No hay datos disponibles desde 2013 en adelante.")
-        return
+    recent_data_mask = df["transaction_year"] >= 2013
+    if recent_data_mask.any():
+        df = df[recent_data_mask]
+    else:
+        min_available_year = int(df["transaction_year"].min())
+        max_available_year = int(df["transaction_year"].max())
+        st.warning(
+            "No se encontraron datos a partir de 2013. Se mostrarán los "
+            f"registros disponibles entre {min_available_year} y {max_available_year}."
+        )
 
     min_year = int(df["transaction_year"].min())
     max_year = int(df["transaction_year"].max())

--- a/sectores_page.py
+++ b/sectores_page.py
@@ -117,7 +117,15 @@ def render():
     country_list_tabla = sorted(df["recipientcountry_codename"].dropna().unique())
     selected_countries_tabla = country_list_tabla
     with st.sidebar:
-        year_range = st.slider("Año", min_year, max_year, (min_year, max_year), step=1)
+        if min_year == max_year:
+            st.info(
+                f"Solo hay datos disponibles para el año {min_year}. Se utilizará ese rango."
+            )
+            year_range = (min_year, max_year)
+        else:
+            year_range = st.slider(
+                "Año", min_year, max_year, (min_year, max_year), step=1
+            )
         subpage = st.radio(
             "Subpáginas",
             [


### PR DESCRIPTION
## Summary
- avoid crashing the sectores sidebar when solo un año está disponible mostrando un aviso y fijando el rango
- permitir que la página de financiamiento muestre datos aun cuando no existan registros posteriores a 2013, informando la situación

## Testing
- python -m compileall financiamiento_page.py sectores_page.py

------
https://chatgpt.com/codex/tasks/task_e_68d534cffe5c8330bdb9d614ca2e83aa