### PR TITLE
Fix transaction date parsing for dashboards

### DIFF
--- a/date_utils.py
+++ b/date_utils.py
@@ -1,0 +1,65 @@
+"""Utility helpers to parse transaction date values consistently."""
+
+from __future__ import annotations
+
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
+
+# Accepted lower/upper bounds for realistic civil years.
+_MIN_VALID_YEAR = 1900
+_MAX_VALID_YEAR = 2100
+
+
+def parse_transaction_dates(series: pd.Series) -> pd.Series:
+    """Return a datetime series from heterogeneous raw date representations.
+
+    The source data combines timestamps stored as integers (days since the Unix
+    epoch), plain years and ISO formatted strings. Pandas will interpret integer
+    values as nanoseconds when ``unit`` is not provided, producing the spurious
+    1970 dates that were showing up in the visualisations. This helper performs
+    a couple of checks to infer the appropriate unit so that the conversion is
+    robust across the different encodings we receive.
+    """
+
+    if is_datetime64_any_dtype(series):
+        return series
+
+    # ``to_numeric`` converts non-numeric entries to ``NaN`` which are then
+    # ignored by the heuristic below. Values <= 0 are treated as missing to
+    # avoid the Epoch (1970) artefact when dealing with filled zeros.
+    numeric = pd.to_numeric(series, errors="coerce") if not is_numeric_dtype(series) else series
+    numeric = pd.to_numeric(numeric, errors="coerce")
+    numeric = numeric.where(numeric > 0)
+    numeric_non_na = numeric.dropna()
+
+    if numeric_non_na.empty:
+        return pd.to_datetime(series, errors="coerce", infer_datetime_format=True)
+
+    # Years stored as integers (e.g. 2014) should map to the first day of that
+    # year instead of the Unix epoch.
+    if numeric_non_na.between(_MIN_VALID_YEAR, _MAX_VALID_YEAR).all():
+        return pd.to_datetime(
+            numeric.astype("Int64").astype(str) + "-01-01", errors="coerce"
+        )
+
+    max_value = float(numeric_non_na.max())
+
+    # Integers around ~10^4 represent days since 1970 in the original files.
+    if max_value < 1_000_000:
+        return pd.to_datetime(
+            numeric, unit="D", origin="1970-01-01", errors="coerce"
+        )
+
+    # Fall back to the usual timestamp units, selecting the first match that
+    # keeps the resulting years in a reasonable range.
+    for unit, threshold in (("s", 1e11), ("ms", 1e14), ("us", 1e17), ("ns", float("inf"))):
+        if max_value < threshold:
+            converted = pd.to_datetime(
+                numeric, unit=unit, origin="1970-01-01", errors="coerce"
+            )
+            years = converted.dt.year.dropna()
+            if not years.empty and years.between(_MIN_VALID_YEAR, _MAX_VALID_YEAR).all():
+                return converted
+
+    # As a last resort defer to pandas' parser.
+    return pd.to_datetime(series, errors="coerce", infer_datetime_format=True)

--- a/financiamiento_page.py
+++ b/financiamiento_page.py
@@ -4,6 +4,8 @@ import plotly.express as px
 import plotly.graph_objects as go
 from itertools import cycle
 
+from date_utils import parse_transaction_dates
+
 COLOR_MAP = {
     "FONPLATA": "#c1121f",
     "IADB": "#003566",
@@ -26,7 +28,9 @@ def build_color_map(sources):
 @st.cache_data
 def load_financiamiento() -> pd.DataFrame:
     df = pd.read_parquet("BDDGLOBALMERGED_ACTUALIZADO.parquet")
-    df["transactiondate_isodate"] = pd.to_datetime(df["transactiondate_isodate"])
+    df["transactiondate_isodate"] = parse_transaction_dates(
+        df["transactiondate_isodate"]
+    )
     return df
 
 

--- a/sectores_page.py
+++ b/sectores_page.py
@@ -6,6 +6,8 @@ from plotly.subplots import make_subplots
 from pandas.api.types import is_string_dtype
 from io import BytesIO
 
+from date_utils import parse_transaction_dates
+
 # Utilidad para manejar multiselect con opción "Seleccionar todo"
 def handle_multiselect_behavior(selected_options, all_options, select_all_text):
     if not selected_options or select_all_text in selected_options:
@@ -58,11 +60,13 @@ def get_mdb_color_map(sources: list[str]) -> dict[str, str]:
 @st.cache_data
 def load_sectores() -> pd.DataFrame:
     df = pd.read_parquet("BDDGLOBALMERGED_ACTUALIZADO.parquet")
-    df["transactiondate_isodate"] = pd.to_datetime(df["transactiondate_isodate"])
+    df["transactiondate_isodate"] = parse_transaction_dates(
+        df["transactiondate_isodate"]
+    )
     if is_string_dtype(df["sector_code"]):
         df["sector_code"] = pd.to_numeric(df["sector_code"], errors="coerce")
     df["sector_code"] = df["sector_code"].astype("Int64")
-    df["year"] = df["transactiondate_isodate"].dt.year
+    df["year"] = df["transactiondate_isodate"].dt.year.astype("Int64")
     df["month"] = df["transactiondate_isodate"].dt.to_period("M").astype(str)
     return df
 


### PR DESCRIPTION
## Summary
- add a helper to normalise transaction dates and prevent Unix epoch artefacts
- use the shared parser in the Sectores and Financiamiento pages and keep their year columns nullable integers

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d53759d7888330861583729bacbc02