### PR TITLE
Limit date filters to 2005-2024

### DIFF
--- a/financiamiento_page.py
+++ b/financiamiento_page.py
@@ -52,19 +52,17 @@ def render() -> None:
     df["recipientcountry_codename"] = df["recipientcountry_codename"].fillna("Sin dato")
     df["transaction_year"] = df["transactiondate_isodate"].dt.year
 
-    recent_data_mask = df["transaction_year"] >= 2013
-    if recent_data_mask.any():
-        df = df[recent_data_mask]
-    else:
-        min_available_year = int(df["transaction_year"].min())
-        max_available_year = int(df["transaction_year"].max())
+    raw_min_year = int(df["transaction_year"].min())
+    raw_max_year = int(df["transaction_year"].max())
+    desired_min_year, desired_max_year = 2005, 2024
+    min_year = max(desired_min_year, raw_min_year)
+    max_year = min(desired_max_year, raw_max_year)
+    if min_year > max_year:
         st.warning(
-            "No se encontraron datos a partir de 2013. Se mostrarán los "
-            f"registros disponibles entre {min_available_year} y {max_available_year}."
+            "No hay datos disponibles entre los años 2005 y 2024. "
+            "Mostrando el rango disponible en la fuente de datos."
         )
-
-    min_year = int(df["transaction_year"].min())
-    max_year = int(df["transaction_year"].max())
+        min_year, max_year = raw_min_year, raw_max_year
 
     country_list = sorted(df["recipientcountry_codename"].unique())
     macro_sectors = sorted(df["macro_sector"].unique())

--- a/sectores_page.py
+++ b/sectores_page.py
@@ -77,7 +77,16 @@ def render():
         fp_min, fp_max = df.loc[fp_mask, "value_usd"].agg(["min", "max"])
     else:
         fp_min = fp_max = 0
-    min_year, max_year = int(df["year"].min()), int(df["year"].max())
+    raw_min_year, raw_max_year = int(df["year"].min()), int(df["year"].max())
+    desired_min_year, desired_max_year = 2005, 2024
+    min_year = max(desired_min_year, raw_min_year)
+    max_year = min(desired_max_year, raw_max_year)
+    if min_year > max_year:
+        st.warning(
+            "No hay datos disponibles entre los años 2005 y 2024. "
+            "Mostrando el rango disponible en la fuente de datos."
+        )
+        min_year, max_year = raw_min_year, raw_max_year
     source_list = sorted(df["source"].dropna().unique())
     selected_sources = source_list
     country_name_map = {


### PR DESCRIPTION
## Summary
- clamp the sector page year slider to the 2005–2024 window while falling back to available data when the range is empty
- enforce the same 2005–2024 limits on the financing page and remove the previous 2013+ restriction so older data can be filtered

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d53a5582408330aa92aa78495ef8cd