### PR TITLE
Remove aggregated private SC3 series from IDS charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,7 +93,11 @@ def get_contrasting_text_color(hex_color: str) -> str:
 # Cargar datos
 @st.cache_data
 def load_data():
-    return pd.read_parquet('IDS.parquet')
+    df_ids = pd.read_parquet('IDS.parquet')
+    if 'SC3' in df_ids.columns:
+        sc3_clean = df_ids['SC3'].astype(str).str.strip().str.lower()
+        df_ids = df_ids[~sc3_clean.eq('private')]
+    return df_ids
 
 df = load_data()
 


### PR DESCRIPTION
## Summary
- filter IDS dataset on load to exclude the aggregated SC3 category "Private"
- prevent duplicated debt data in IDS charts by keeping only detailed private creditor groupings

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68dfea5c2130833087b3294d3a64d088