### PR TITLE
Exclude Official and concessional SC3 categories from external debt charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -197,6 +197,10 @@ if pagina == 'Deuda externa':
     if pais in df_filtrado.columns:
         df_pais = df_filtrado[["SC3", "Time", pais]].dropna()
         df_pais = df_pais[~df_pais["SC3"].str.contains("All creditors", case=False, na=False)]
+        excluded_sc3 = {"official", "bilateral concessional", "multilateral concessional"}
+        df_pais = df_pais[
+            ~df_pais["SC3"].str.strip().str.lower().isin(excluded_sc3)
+        ]
         # Tomar el valor máximo por año y SC3 para evitar duplicados (mantiene el valor más significativo)
         df_pais_agg = df_pais.groupby(['Time', 'SC3'])[pais].max().reset_index()
         # Paleta de colores específica para categorías de deuda externa


### PR DESCRIPTION
## Summary
- filter the external debt dataset to drop the Official, Bilateral Concessional, and Multilateral Concessional SC3 categories before plotting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfed864c248330a1b5df770c80ca85